### PR TITLE
grpc-web: migrate to grpc

### DIFF
--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -7,24 +7,68 @@
 <body>
   <script src="../../dist/bundle.js"></script>
   <script>
-    (function () {
-      // Create a new client and connect
-      window.client = new threads.Client()
-      client.connect('ws://localhost:8080').then(() => {
 
-        // Subscribe to thread(s) in URL query
-        const params = new URLSearchParams(window.location.search)
-        if (params.has('thread')) {
-          client.subscribe(params.getAll('thread'), (rec) => {
-            console.debug('Got new record:', rec)
-          }).then((token) => {
-            console.debug('Subscription started:', token)
-          }).catch((err) => {
-            console.error(err)
-          })
+    const personSchema = {
+      "$id": "https://example.com/person.schema.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Person",
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "description": "The person's first name."
+        },
+        "lastName": {
+          "type": "string",
+          "description": "The person's last name."
+        },
+        "age": {
+          "description": "Age in years which must be equal to or greater than zero.",
+          "type": "integer",
+          "minimum": 0
         }
+      }
+    };
 
-      })
+    const adam = {
+      "firstName": "Adam",
+      "lastName": "Doe",
+      "age": 21
+    };
+
+    const eve = {
+      "firstName": "Eve",
+      "lastName": "Doe",
+      "age": 21
+    };
+
+    (async function () {
+
+      window.client = new threads.Client().setHost('http://localhost:9091')
+      try {
+        const res = await client.newStore()
+        const storeID = res.id
+        await client.registerSchema(storeID, 'Person', personSchema)
+        const people = await client.modelCreate(storeID, 'Person', [adam, eve])
+        console.debug(people.entityidsList) // list created ids
+      }
+      catch (err) {
+        console.error(err)
+      }
+
+      // @todo: re-enable subscriptions
+      // // Subscribe to thread(s) in URL query
+      // const params = new URLSearchParams(window.location.search)
+      // if (params.has('thread')) {
+      //   client.subscribe(params.getAll('thread'), (rec) => {
+      //     console.debug('Got new record:', rec)
+      //   }).then((token) => {
+      //     console.debug('Subscription started:', token)
+      //   }).catch((err) => {
+      //     console.error(err)
+      //   })
+      // }
+
     })()
   </script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,6 +192,14 @@
         }
       }
     },
+    "@improbable-eng/grpc-web": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.11.0.tgz",
+      "integrity": "sha512-SS2YP6iHyZ7TSSuCShnSo9xJyUkNZHEhEPJpTSUcNoULe1LuLEk52OKHY+VW9XB0qXstejpHgZq2Hx+69PThiw==",
+      "requires": {
+        "browser-headers": "^0.4.0"
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -446,6 +454,11 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/google-protobuf": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.7.2.tgz",
+      "integrity": "sha512-ifFemzjNchFBCtHS6bZNhSZCBu7tbtOe0e8qY0z2J4HtFXmPJjm6fXSaQsTG7yhShBEZtt2oP/bkwu5k+emlkQ=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -1477,6 +1490,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
+    },
+    "browser-headers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
+      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
@@ -4778,6 +4796,11 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "google-protobuf": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.10.0.tgz",
+      "integrity": "sha512-d0cMO8TJ6xtB/WrVHCv5U81L2ulX+aCD58IljyAN6mHwdHHJ2jbcauX5glvivi3s3hx7EYEo7eUA9WftzamMnw=="
     },
     "got": {
       "version": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
   "author": "textile.io",
   "license": "MIT",
   "dependencies": {
+    "@improbable-eng/grpc-web": "^0.11.0",
+    "@types/google-protobuf": "^3.7.2",
+    "google-protobuf": "^3.10.0",
     "isomorphic-ws": "^4.0.1",
     "uuid": "^3.3.3",
     "ws": "^7.2.0"

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,6 +1,6 @@
 import {Client} from '../index'
 
-const url = 'ws://localhost:8080'
+const host = 'http://localhost:9091'
 const client = new Client()
 
 describe('version', () => {
@@ -9,8 +9,8 @@ describe('version', () => {
   })
 })
 
-describe.skip('connect', () => {
+describe('setHost', () => {
   it('should resolve', async () => {
-    expect(await client.connect(url)).toBeUndefined()
+    expect(await client.setHost(host)).toBeDefined()
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export class Client {
     return this.unary(API.ModelCreate, req)
   }
 
-  public async unary<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends UnaryMethodDefinition<TRequest, TResponse>>(
+  private async unary<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends UnaryMethodDefinition<TRequest, TResponse>>(
       methodDescriptor: M, req: TRequest) {
     return new Promise((resolve, reject) => {
       if (!this.host) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,15 @@
 import * as uuid from 'uuid'
+import {grpc} from '@improbable-eng/grpc-web'
+import {API} from '@textile/threads-api-pb/api_pb_service'
+import {
+  NewStoreRequest,
+  RegisterSchemaRequest,
+  ModelCreateRequest
+} from '@textile/threads-api-pb/api_pb'
+import {ProtobufMessage} from '@improbable-eng/grpc-web/dist/typings/message'
+import {UnaryMethodDefinition} from '@improbable-eng/grpc-web/dist/typings/service'
 
-const WebSocket = require('isomorphic-ws')
 const pack = require('../package.json')
-
-interface Message {
-  id?: string
-  type?: string
-  status?: 'ok' | 'error'
-  body?: string
-  error?: string
-}
-
-export interface LogRecord {
-  id: string
-  log_id?: string
-  thread_id: string
-  record_node?: string
-  event_node?: string
-  header_node?: string
-  body_node?: string
-}
-
-interface Subscription {
-  threads: string[]
-  handler: (rec: LogRecord) => void
-}
 
 export class Client {
 
@@ -32,120 +17,73 @@ export class Client {
     return pack.version
   }
 
-  private socket: WebSocket | undefined
-  private requests: Record<string, (res: Message) => void> = {}
-  private subscriptions: Record<string, Subscription> = {}
+  private host: string | undefined
+  // private subscriptions: Record<string, Subscription> = {}
 
-  public async connect(url: string) {
-    return new Promise((resolve, reject) => {
-      this.socket = new WebSocket(url) as WebSocket
+  constructor() {
+    grpc.setDefaultTransport(grpc.FetchReadableStreamTransport({
+      credentials: 'omit'
+    }))
+    // grpc.setDefaultTransport(grpc.WebsocketTransport())
+  }
 
-      this.socket.onopen = () => {
-        console.debug('Connection opened.')
-        resolve()
-      }
-      this.socket.onclose = () => {
-        console.debug('Connection closed.')
-      }
-      this.socket.onerror = (e) => {
-        console.error(e)
-        reject(e)
-      }
-      this.socket.onmessage = (e) => {
-        this.handleEvent(e)
-      }
+  public setHost(host: string) {
+    this.host = host
+    return this
+  }
+
+  public async newStore() {
+    return this.unary(API.NewStore, new NewStoreRequest())
+  }
+
+  public async registerSchema(storeID: string, name: string, schema: any) {
+    const req = new RegisterSchemaRequest()
+    req.setStoreid(storeID)
+    req.setName(name)
+    req.setSchema(JSON.stringify(schema))
+    return this.unary(API.RegisterSchema, req)
+  }
+
+  public async modelCreate(storeID: string, modelName: string, values: any[]) {
+    const req = new ModelCreateRequest()
+    req.setStoreid(storeID)
+    req.setModelname(modelName)
+
+    const list: any[] = []
+    values.forEach((v) => {
+      v['ID'] = uuid.v4()
+      list.push(JSON.stringify(v))
     })
+    req.setValuesList(list)
+
+    return this.unary(API.ModelCreate, req)
   }
 
-  public async addThread(addr: string, followKey: string, readKey: string) {
-    return this.send('addThread', [addr, followKey, readKey])
-  }
-
-  public async pullThread(id: string) {
-    return this.send('pullThread', [id])
-  }
-
-  public async deleteThread(id: string) {
-    return this.send('deleteThread', [id])
-  }
-
-  public async addFollower(addr: string) {
-    return this.send('addFollower', [addr])
-  }
-
-  public async addRecord(body: any, threadID: string) {
-    return this.send('addRecord', [JSON.stringify(body), threadID])
-  }
-
-  public async getRecord(recordID: string, threadID: string) {
-    return this.send('getRecord', [threadID, recordID])
-  }
-
-  public async subscribe(threads: string[], handler: (rec: LogRecord) => void) {
-    return this.send('subscribe', threads).then(() => {
-      const token = uuid.v4()
-      this.subscriptions[token] = {
-        threads,
-        handler
-      }
-      return token
-    })
-  }
-
-  protected async send(method: string, args: string[]) {
+  public async unary<TRequest extends ProtobufMessage, TResponse extends ProtobufMessage, M extends UnaryMethodDefinition<TRequest, TResponse>>(
+      methodDescriptor: M, req: TRequest) {
     return new Promise((resolve, reject) => {
-      if (this.socket === undefined) {
-        reject('Connection required.')
+      if (!this.host) {
+        reject(new Error('host URL is not set'))
         return
       }
 
-      const id = uuid.v4()
-      this.requests[id] = (res: Message) => {
-        if (res.error) {
-          reject(new Error(res.error))
-        } else if (res.body) {
-          resolve(JSON.parse(res.body) as LogRecord)
-        } else {
-          resolve()
-        }
-      }
-
-      this.socket.send(JSON.stringify({
-        id,
-        method,
-        args
-      }))
-    })
-  }
-
-  private handleEvent(event: MessageEvent) {
-    const res = JSON.parse(event.data) as Message
-
-    switch (res.type) {
-      case 'newRecord':
-        if (res.body === undefined) {
-          console.error('missing message body')
-          return
-        }
-        const body = JSON.parse(res.body) as LogRecord
-        Object.keys(this.subscriptions).forEach((token) => {
-          const sub = this.subscriptions[token]
-          sub.threads.forEach((id) => {
-            if (id === body.thread_id) {
-              sub.handler(body)
+      grpc.unary(methodDescriptor, {
+        request: req,
+        host: this.host,
+        onEnd: (res) => {
+          const { status, statusMessage, headers, message, trailers } = res
+          if (status === grpc.Code.OK) {
+            if (message) {
+              resolve(message.toObject())
+            } else {
+              resolve()
             }
-          })
-        })
-        break
-      case 'response':
-        if (res.id && this.requests[res.id]) {
-          this.requests[res.id](res)
-          delete this.requests[res.id]
+          } else {
+            reject(new Error(statusMessage))
+          }
         }
-        break
-      default:
-        console.error(new Error('unknown message type: ' + res.type))
-    }
+      })
+    })
   }
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -41,6 +41,7 @@
     "semicolon": [true, "never"],
     "jsx-no-multiline-js": false,
     "no-object-literal-type-assertion": false,
+    "no-implicit-dependencies": [false, "dev"],
     "trailing-comma": [
       true,
       {
@@ -52,4 +53,3 @@
   },
   "rulesDirectory": []
 }
-  


### PR DESCRIPTION
- Migrates the WS rpc handling to gRPC-web
- Puts the focus on the store, not the threadservice, but we should expose that as well

In order to test this locally, you can:

```
npm install
npm link @textile/threads-api-pb
```