### PR TITLE
Switch to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "test": "jest --no-watchman",
     "lint": "./node_modules/tslint/bin/tslint  -c tslint.json --project .",
     "docs": "./node_modules/typedoc/bin/typedoc",


### PR DESCRIPTION
Makes it so that it won't automatically try to run tsc locally on install. This is good for two reasons: 
1) for users, if the local build fails, at least the package will still contain the compiled ts files
2) for development, when working with linked packages, rebuilding overwrites this and is a pain