### PR TITLE
Returns actual objects, optionally typed if using generics

### DIFF
--- a/src/ReadTransaction.ts
+++ b/src/ReadTransaction.ts
@@ -9,7 +9,10 @@ import {
   ReadTransactionRequest,
   ReadTransactionReply,
 } from '@textile/threads-client-grpc/api_pb'
+import { toBase64, fromBase64 } from 'b64-lite'
 import { Transaction } from './Transaction'
+import { Entity, EntityList } from './models'
+import { JSONQuery } from './query'
 
 export class ReadTransaction extends Transaction<ReadTransactionRequest, ReadTransactionReply> {
   public async start() {
@@ -23,43 +26,58 @@ export class ReadTransaction extends Transaction<ReadTransactionRequest, ReadTra
   }
 
   public async has(entityIDs: string[]) {
-    return new Promise<ModelHasReply.AsObject>((resolve, reject) => {
+    return new Promise<boolean>((resolve, reject) => {
       const hasReq = new ModelHasRequest()
       hasReq.setEntityidsList(entityIDs)
       const req = new ReadTransactionRequest()
       req.setModelhasrequest(hasReq)
       this.client.onMessage((message: ReadTransactionReply) => {
         const reply = message.getModelhasreply()
-        resolve(reply ? reply.toObject() : undefined)
+        resolve(reply ? reply.toObject().exists == true : false)
       })
       this.setReject(reject)
       this.client.send(req)
     })
   }
 
-  public async modelFind() {
-    return new Promise<ModelFindReply.AsObject>((resolve, reject) => {
+  public async modelFind<T = any>(query: JSONQuery) {
+    return new Promise<EntityList<T>>((resolve, reject) => {
       const findReq = new ModelFindRequest()
+      findReq.setQueryjson(toBase64(JSON.stringify(query)))
       const req = new ReadTransactionRequest()
       req.setModelfindrequest(findReq)
       this.client.onMessage((message: ReadTransactionReply) => {
         const reply = message.getModelfindreply()
-        resolve(reply ? reply.toObject() : undefined)
+        if (reply === undefined) {
+          resolve()
+        } else {
+          const ret: EntityList<T> = {
+            entitiesList: reply.toObject().entitiesList.map(entity => JSON.parse(fromBase64(entity as string))),
+          }
+          resolve(ret)
+        }
       })
       this.setReject(reject)
       this.client.send(req)
     })
   }
 
-  public async modelFindByID(entityID: string) {
-    return new Promise<ModelFindByIDReply.AsObject>((resolve, reject) => {
+  public async modelFindByID<T = any>(entityID: string) {
+    return new Promise<Entity<T>>((resolve, reject) => {
       const findReq = new ModelFindByIDRequest()
       findReq.setEntityid(entityID)
       const req = new ReadTransactionRequest()
       req.setModelfindbyidrequest(findReq)
       this.client.onMessage((message: ReadTransactionReply) => {
         const reply = message.getModelfindbyidreply()
-        resolve(reply ? reply.toObject() : undefined)
+        if (reply === undefined) {
+          resolve()
+        } else {
+          const ret: Entity<T> = {
+            entity: JSON.parse(reply.toObject().entity as string),
+          }
+          resolve(ret)
+        }
       })
       this.setReject(reject)
       this.client.send(req)

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,7 @@
+export interface Entity<T> {
+  entity: T
+}
+
+export interface EntityList<T> {
+  entitiesList: T[]
+}


### PR DESCRIPTION
This returns actual JS objects from all API calls, for a more intuitive API. No more JSON.parse! The really nice thing here is it uses generics to pretty good effect (probs could be better at inferring), so that for example, when performing a `Find` the caller can specify _what_ type of response to give back:

```
interface Person {
  ID: string
  firstName: string
  lastName: string
  age: number
}
...
const q: JSONQuery = {
  ands: [{
    fieldPath: 'firstName',
    operation: JSONOperation.Eq,
    value: { string: 'Carson' },
  }]
}
// Note the use of a type specification in the generic `modelFind` method:
const find = await client.modelFind<Person>(store.id, 'Person', q)
const found = find.entitiesList
// found is Person[]
```

Note that if you don't supply a generic type, it'll just return `any`, which is pretty much as good as we can do for now.