### PR TITLE
Update to latest go-threads image

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -33,10 +33,10 @@ jobs:
 
     - name: Install
       run: npm install
-      
+
     - name: Lint
       run: npm run lint
-      
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -44,10 +44,12 @@ jobs:
 
     services:
       threads:
-        image: textile/go-threads
+        image: textile/go-threads:latest
+        env:
+          THRDS_APIPROXYADDR: /ip4/0.0.0.0/tcp/6007
         ports:
-        - 6007:6007
-        
+          - "127.0.0.1:6107:6007"
+
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           THRDS_APIPROXYADDR: /ip4/0.0.0.0/tcp/6007
         ports:
-          - "127.0.0.1:6107:6007"
+          - "127.0.0.1:6007:6007"
 
     steps:
     - name: Checkout

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -7,13 +7,13 @@
 import { expect } from 'chai'
 import { NewStoreReply } from '@textile/threads-client-grpc/api_pb'
 import { WriteTransaction } from 'src/WriteTransaction'
+import { ReadTransaction } from 'src/ReadTransaction'
 import { Client } from '../index'
 import { JSONQuery, JSONOperation } from '../models'
 import { Where } from '../query'
-import { ReadTransaction } from 'src/ReadTransaction'
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-const client = new Client('http://localhost:6007')
+const client = new Client('http://127.0.0.1:6107')
 
 const personSchema = {
   $id: 'https://example.com/person.schema.json',

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -13,7 +13,7 @@ import { JSONQuery, JSONOperation } from '../models'
 import { Where } from '../query'
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-const client = new Client('http://127.0.0.1:6107')
+const client = new Client('http://127.0.0.1:6007')
 
 const personSchema = {
   $id: 'https://example.com/person.schema.json',


### PR DESCRIPTION
cc @andrewxhill and @eightysteele 

This updates CI to latest default ports etc in go-threads image. This should now match those used in js-threads and go-threads testing environments.