### PR TITLE
WIP: Proof of concept—adding cloud auth via `session_id`

### DIFF
--- a/src/ReadTransaction.ts
+++ b/src/ReadTransaction.ts
@@ -1,3 +1,4 @@
+import { grpc } from '@improbable-eng/grpc-web'
 import {
   ModelHasRequest,
   ModelFindRequest,
@@ -24,7 +25,9 @@ export class ReadTransaction extends Transaction<ReadTransactionRequest, ReadTra
     startReq.setModelname(this.modelName)
     const req = new ReadTransactionRequest()
     req.setStarttransactionrequest(startReq)
-    this.client.start()
+    var metadata = new grpc.Metadata()
+    metadata.set('Authorization', 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7')
+    this.client.start(metadata)
     this.client.send(req)
   }
 

--- a/src/WriteTransaction.ts
+++ b/src/WriteTransaction.ts
@@ -1,3 +1,4 @@
+import { grpc } from '@improbable-eng/grpc-web'
 import * as uuid from 'uuid'
 import {
   ModelCreateRequest,
@@ -28,7 +29,9 @@ export class WriteTransaction extends Transaction<WriteTransactionRequest, Write
     startReq.setModelname(this.modelName)
     const req = new WriteTransactionRequest()
     req.setStarttransactionrequest(startReq)
-    this.client.start()
+    var metadata = new grpc.Metadata()
+    metadata.set('Authorization', 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7')
+    this.client.start(metadata)
     this.client.send(req)
   }
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,9 +312,11 @@ export class Client {
       filter.setEntityid(entityID)
       req.addFilters(filter)
     }
+    var metadata = {'Authorization': 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7'};
     const res = grpc.invoke(API.Listen, {
       host: this.host,
       request: req,
+      metadata:metadata,
       onMessage: (rec: ListenReply) => {
         const ret: Entity<T> = {
           entity: JSON.parse(Buffer.from(rec.getEntity_asU8()).toString()),
@@ -328,16 +330,7 @@ export class Client {
         callback()
       },
     })
-<<<<<<< HEAD
     return res.close.bind(res)
-=======
-    var metadata = new grpc.Metadata()
-    metadata.set('Authorization', 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7')
-    client.start(metadata)
-    client.send(req)
-    // Bind to client here because the close call uses 'this'...
-    return client.close.bind(client)
->>>>>>> proof of concept for cloud auth
   }
 
   private async unary<
@@ -346,7 +339,6 @@ export class Client {
     M extends grpc.UnaryMethodDefinition<TRequest, TResponse>
   >(methodDescriptor: M, req: TRequest) {
     var metadata = {'Authorization': 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7'};
-    console.log(metadata)
     return new Promise((resolve, reject) => {
       grpc.unary(methodDescriptor, {
         request: req,
@@ -356,7 +348,6 @@ export class Client {
           const { status, statusMessage, message } = res
           if (status === grpc.Code.OK) {
             if (message) {
-              console.log(statusMessage)
               resolve(message.toObject())
             } else {
               resolve()

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,7 +269,7 @@ export class Client {
   public readTransaction(storeID: string, modelName: string): ReadTransaction {
     var metadata = {'Authorization': 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7'};
     const client = grpc.client(API.ReadTransaction, {
-      host: this.host
+      host: this.host,
     }) as grpc.Client<ReadTransactionRequest, ReadTransactionReply>
     return new ReadTransaction(client, storeID, modelName)
   }
@@ -316,7 +316,7 @@ export class Client {
     const res = grpc.invoke(API.Listen, {
       host: this.host,
       request: req,
-      metadata:metadata,
+      metadata: metadata,
       onMessage: (rec: ListenReply) => {
         const ret: Entity<T> = {
           entity: JSON.parse(Buffer.from(rec.getEntity_asU8()).toString()),

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,8 +267,9 @@ export class Client {
    * @param modelName The human-readable name of the model to use.
    */
   public readTransaction(storeID: string, modelName: string): ReadTransaction {
+    var metadata = {'Authorization': 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7'};
     const client = grpc.client(API.ReadTransaction, {
-      host: this.host,
+      host: this.host
     }) as grpc.Client<ReadTransactionRequest, ReadTransactionReply>
     return new ReadTransaction(client, storeID, modelName)
   }
@@ -327,7 +328,16 @@ export class Client {
         callback()
       },
     })
+<<<<<<< HEAD
     return res.close.bind(res)
+=======
+    var metadata = new grpc.Metadata()
+    metadata.set('Authorization', 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7')
+    client.start(metadata)
+    client.send(req)
+    // Bind to client here because the close call uses 'this'...
+    return client.close.bind(client)
+>>>>>>> proof of concept for cloud auth
   }
 
   private async unary<
@@ -335,14 +345,18 @@ export class Client {
     TResponse extends grpc.ProtobufMessage,
     M extends grpc.UnaryMethodDefinition<TRequest, TResponse>
   >(methodDescriptor: M, req: TRequest) {
+    var metadata = {'Authorization': 'Bearer 087e5814-b44a-4732-a15c-824bfacd4da7'};
+    console.log(metadata)
     return new Promise((resolve, reject) => {
       grpc.unary(methodDescriptor, {
         request: req,
         host: this.host,
+        metadata: metadata,
         onEnd: res => {
           const { status, statusMessage, message } = res
           if (status === grpc.Code.OK) {
             if (message) {
+              console.log(statusMessage)
               resolve(message.toObject())
             } else {
               resolve()


### PR DESCRIPTION
Putting up this WIP PR for visibility—it basically flushes out a proof of concept for cloud auth via the `Authorization: Bearer {session_id}` request header. Everything is hard coded for now, so still needs some work. All tests pass via `npm run test:node` against the Textile daemon running locally.

cc: @andrewxhill 