### PR TITLE
core: allow simplified config startup

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { grpc } from '@improbable-eng/grpc-web'
 
+export type BaseConfig = {
+  host?: string
+  transport?: grpc.TransportFactory
+}
+
 export class Config {
   public host: string
   public transport: grpc.TransportFactory

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,37 +1,21 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { grpc } from '@improbable-eng/grpc-web'
 
-export type BaseConfig = {
+export interface BaseConfig {
   host?: string
   transport?: grpc.TransportFactory
 }
 
 export class Config {
-  public host: string
-  public transport: grpc.TransportFactory
-
-  public session?: string
-  constructor(host?: string, transport?: grpc.TransportFactory) {
-    this.host = host || 'http://127.0.0.1:6007'
-    this.transport = transport || grpc.WebsocketTransport()
-  }
+  constructor(
+    public host: string = 'http://127.0.0.1:6007',
+    public transport: grpc.TransportFactory = grpc.WebsocketTransport(),
+  ) {}
 
   _wrapMetadata(values?: { [key: string]: any }): { [key: string]: any } | undefined {
-    if (!this.session) {
-      return values
-    }
-    const response = values ?? {}
-    if ('Authorization' in response || 'authorization' in response) {
-      return response
-    }
-    response['Authorization'] = `Bearer ${this.session}`
-    return response
+    return values
   }
   _wrapBrowserHeaders(values: grpc.Metadata): grpc.Metadata {
-    if (!this.session) {
-      return values
-    }
-    values.set('Authorization', `Bearer ${this.session}`)
     return values
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,10 @@ import { encode, decode } from 'bs58'
 import * as pack from '../package.json'
 import { ReadTransaction } from './ReadTransaction'
 import { WriteTransaction } from './WriteTransaction'
-import { Config } from './config'
+import { Config, BaseConfig } from './config'
 import { JSONQuery, Entity, EntityList } from './models'
 
-export { Config, Entity, EntityList, JSONQuery }
+export { BaseConfig, Config, Entity, EntityList, JSONQuery }
 export { Query, Where } from './query'
 
 /**
@@ -60,8 +60,12 @@ export class Client {
    * @param host The local/remote host url. Defaults to 'localhost:6007'.
    * @param defaultTransport The default transport to use when making webgRPC calls. Defaults to WebSockets.
    */
-  constructor(config?: Config) {
-    this.config = config || new Config()
+  constructor(config: Config | BaseConfig = {}) {
+    if (config instanceof Config) {
+      this.config = config
+    } else {
+      this.config = new Config(config.host, config.transport)
+    }
     grpc.setDefaultTransport(this.config.transport)
   }
 


### PR DESCRIPTION
I had left this in a kinda ugly state where, to start the client with custom configs you needed to do something like,

```typescript
const config = new Config('http://10.98.239.0:80')
this.client = new Client(config)
```

this just cleans that up so you can do,

```
this.client = new Client({host: 'http://10.98.239.0:80'})
```