### PR TITLE
WIP—Suggested fix for gRPC headers errors in the thread-shell (#130)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,11 @@
         "browser-headers": "^0.4.0"
       }
     },
+    "@improbable-eng/grpc-web-node-http-transport": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.12.0.tgz",
+      "integrity": "sha512-+Kjz+Dktfz5LKTZA9ZW/Vlww6HF9KaKz4x2mVe1O8CJdOP2WfzC+KY8L6EWMqVLrV4MvdBuQdSgDmvSJz+OGuA=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -6885,6 +6890,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -57,12 +57,14 @@
   "license": "MIT",
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.12.0",
+    "@improbable-eng/grpc-web-node-http-transport": "^0.12.0",
     "@textile/threads-client-grpc": "^0.1.6",
     "@types/google-protobuf": "^3.7.2",
     "b64-lite": "^1.4.0",
     "bs58": "^4.0.1",
     "google-protobuf": "^3.10.0",
     "isomorphic-ws": "^4.0.1",
+    "node-fetch": "^2.6.0",
     "uuid": "^3.3.3",
     "ws": "^7.2.0"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { grpc } from '@improbable-eng/grpc-web'
+import {NodeHttpTransport} from "@improbable-eng/grpc-web-node-http-transport";
 
 export interface BaseConfig {
   host?: string
@@ -9,7 +10,7 @@ export interface BaseConfig {
 export class Config {
   constructor(
     public host: string = 'http://127.0.0.1:6007',
-    public transport: grpc.TransportFactory = grpc.WebsocketTransport(),
+    public transport: grpc.TransportFactory = NodeHttpTransport(),
   ) {}
 
   _wrapMetadata(values?: { [key: string]: any }): { [key: string]: any } | undefined {


### PR DESCRIPTION
This is a WIP for #130—definitely not ready to merge, but maybe making a bit of progress.

I swapped out `grpc.WebsocketTransport` for `NodeHttpTransport`. All tests pass (npm test) except for transactions (`Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.`):

```
.readTransaction
      ✓ should start a transaction
      1) should able to check for an existing entity
      2) should be able to find an existing entity
      ✓ should be able to close/end an transaction
.writeTransaction
      ✓ should start a transaction
      3) should be able to create an entity
      4) should able to check for an existing entity
      5) should be able to find an existing entity
      6) should be able to save an existing entity
      ✓ should be able to close/end an transaction
```

Done for the evening and will pick it back up tomorrow. :)

cc: @sanderpick @carsonfarmer 
